### PR TITLE
Us520435 k fold splitter return kpairs train test

### DIFF
--- a/src/cocohelper/splitters/proportional.py
+++ b/src/cocohelper/splitters/proportional.py
@@ -75,7 +75,7 @@ class ProportionalDataSplitter(Splitter):
         random.shuffle(list_of_image_ids)
 
         n_images = len(list_of_image_ids)
-        n_samples = [int(round(v * n_images)) for v in self.proportions]
+        n_samples = self._get_n_samples(n_images)
         ids_subset_images: List[List[int]] = [list() for _ in self.proportions]
         id_list = list_of_image_ids
         for k, n in enumerate(n_samples):
@@ -84,3 +84,23 @@ class ProportionalDataSplitter(Splitter):
             id_list = right
 
         return ids_subset_images
+
+    def _get_n_samples(self, n_images):
+        """
+        Get the number of samples for each split.
+        Args:
+            n_images: the total number of images in the dataset.
+
+        Returns:
+            A list of integers with the number of samples for each split.
+        """
+        n_samples = [int(round(v * n_images)) for v in self.proportions]
+        num = n_images - sum(n_samples)
+        for i in range(len(n_samples)):
+            if num > 0:
+                n_samples[i] += 1
+                num -= 1
+            else:
+                break
+
+        return n_samples

--- a/tests/unit/test_cocohelper/test_splitter.py
+++ b/tests/unit/test_cocohelper/test_splitter.py
@@ -2,15 +2,20 @@ from cocohelper import COCOHelper
 from cocohelper.splitters.proportional import ProportionalDataSplitter
 from cocohelper.splitters.kfold import KFoldSplitter
 from cocohelper.splitters.stratified import StratifiedDataSplitter
+import pytest
 
 
-# TODO: improve test suite, use AAA approach (Arrange, Act, Assert), use pytest test Classes and fixtures.
+@pytest.fixture()
+def ch():
+    return COCOHelper.load_json('tests/data/coco_dataset/annotations/coco.json')
 
-ch = COCOHelper.load_json('tests/data/coco_dataset/annotations/coco.json')
-ch_stratified = COCOHelper.load_json('tests/data/coco_dataset/annotations/coco_stratified.json')
+
+@pytest.fixture()
+def ch_stratified():
+    return COCOHelper.load_json('tests/data/coco_dataset/annotations/coco_stratified.json')
 
 
-def test_input_list_split():
+def test_input_list_split(ch):
     """ Feeding a series of numbers or a list of numbers should be equivalent"""
     splitter = ProportionalDataSplitter(1, 2, 1)
     result1 = splitter.apply(ch)
@@ -20,7 +25,7 @@ def test_input_list_split():
         assert len(sset[0].imgs) == len(sset[1].imgs)
 
 
-def test_int_split():
+def test_int_split(ch):
     splitter = ProportionalDataSplitter(70, 30)
     train, test = splitter.apply(ch)
 
@@ -32,7 +37,7 @@ def test_int_split():
     assert len(test.imgs) == test_len
 
 
-def test_float_split():
+def test_float_split(ch):
     splitter = ProportionalDataSplitter(0.7, 0.3)
     train, test = splitter.apply(ch)
 
@@ -44,7 +49,7 @@ def test_float_split():
     assert len(test.imgs) == test_len
 
 
-def test_args_split():
+def test_args_split(ch):
     splitter = ProportionalDataSplitter(0.7, 0.3)
     train, test = splitter.apply(ch)
 
@@ -56,7 +61,7 @@ def test_args_split():
     assert len(test.imgs) == test_len
 
 
-def test_stratified_split():
+def test_stratified_split(ch_stratified):
     splitter = StratifiedDataSplitter(0.75, 0.25)
     splits = splitter.apply(ch_stratified)
 
@@ -67,7 +72,7 @@ def test_stratified_split():
     assert s0_props.equals(s1_props)
 
 
-def test_kfold_split():
+def test_kfold_split(ch):
     splitter = KFoldSplitter(n_fold=7)
     splits = splitter.apply(ch)
     assert len(splits) == 7
@@ -75,7 +80,7 @@ def test_kfold_split():
         assert len(split.imgs) == 2
 
 
-def test_stratified_kfold_split():
+def test_stratified_kfold_split(ch_stratified):
     splitter = KFoldSplitter(n_fold=3, stratified=True)
     splits = splitter.apply(ch)
     assert len(splits) == 3
@@ -83,7 +88,7 @@ def test_stratified_kfold_split():
         assert len(split.imgs) > 0
 
 
-def test_kfold_iter():
+def test_kfold_iter(ch):
     splitter = KFoldSplitter(n_fold=7)
     i = 0
     for train, val in splitter.iter(ch):


### PR DESCRIPTION
Implemented the following upgrades:

1. in proportional._get_ids: fixed bug with k-splits, for k>2, in fact sometimes n_samples was incorrect --> implemented new private function named _get_n_samples that calculates the number of samples for each split.
2. KFoldSplitter: requested to modify apply function or add a new function to returns k-pairs of train/test -> bug closed without actions due to already existing function (check KFoldSplitter.iter)
2. test_splitter: unit tests modified to run with the pytest lib

