### PR TITLE
Us520431 return error dictionary for coco validator.validate dataset

### DIFF
--- a/src/cocohelper/dataframe.py
+++ b/src/cocohelper/dataframe.py
@@ -285,6 +285,6 @@ class COCODataFrame(DataFrame):
             include_index: bool = False,
     ) -> Union[dict, List[dict]]:
         if include_index:
-            return self.reset_index().to_dict(orient, into)
-        return super().to_dict(orient, into)
+            return self.reset_index().to_dict(orient, into=into)
+        return super().to_dict(orient, into=into)
 

--- a/src/cocohelper/validator.py
+++ b/src/cocohelper/validator.py
@@ -52,55 +52,90 @@ class COCOValidator:
         logging.info(" | Test passed.")
         return True
 
-    def validate_dataset(self) -> bool:
+    def validate_dataset(self) -> Tuple[bool, dict]:
         """
         Check if this is a valid COCO dataset.
 
         Returns:
             True if this is a valida dataset.
         """
+        error_dict = dict()
+        is_valid = True
+
         logging.info("\n")
         logging.info("Checking COCO dataset validity...")
         fail_message = " | Test failed: this is not a valid COCO dataset:"
 
-        # check folder tree:
-        if not self._has_valid_dataset_tree(self.dataset_dir):
+        # check folder tree
+        error_dict["has_valid_dataset_tree"] = self._has_valid_dataset_tree(self.dataset_dir)
+        is_valid = is_valid and error_dict["has_valid_dataset_tree"]
+        if not error_dict["has_valid_dataset_tree"]:
             logging.error(f"{fail_message} Folders are not organised as expected by a COCO dataset.")
-            return False
 
         # start verifying dataset validity
-        if not self._json_has_mandatory_keys(self.json_data):
+        error_dict["json_has_mandatory_keys"] = self._json_has_mandatory_keys(self.json_data)
+        is_valid = is_valid and error_dict["json_has_mandatory_keys"]
+        if not error_dict["json_has_mandatory_keys"]:
             logging.error(f"{fail_message} There are missing mandatory keys in the json file.")
-            return False
-        if not self._categories_have_mandatory_keys(self.json_data):
+
+        # check if the categories have the mandatory keys
+        error_dict["categories_have_mandatory_keys"] = self._categories_have_mandatory_keys(self.json_data)
+        is_valid = is_valid and error_dict["categories_have_mandatory_keys"]
+        if not error_dict["categories_have_mandatory_keys"]:
             logging.error(f"{fail_message} There are missing mandatory keys in the COCO categories.")
-            return False
-        if not self._images_have_mandatory_keys(self.json_data):
+
+        # check if the images have the mandatory keys
+        error_dict["images_have_mandatory_keys"] = self._images_have_mandatory_keys(self.json_data)
+        is_valid = is_valid and error_dict["images_have_mandatory_keys"]
+        if not error_dict["images_have_mandatory_keys"]:
             logging.error(f"{fail_message} There are missing mandatory keys in the COCO images.")
-            return False
-        if not self._annotations_have_mandatory_keys(self.json_data):
+
+        # check if the annotations have the mandatory keys
+        error_dict["annotations_have_mandatory_keys"] = self._annotations_have_mandatory_keys(self.json_data)
+        is_valid = is_valid and error_dict["annotations_have_mandatory_keys"]
+        if not error_dict["annotations_have_mandatory_keys"]:
             logging.error(f"{fail_message} There are missing mandatory keys in the COCO annotations.")
-            return False
-        if not self._category_ids_are_unique(self.json_data):
+
+        # check if the category ids are unique
+        error_dict["category_ids_are_unique"] = self._category_ids_are_unique(self.json_data)
+        is_valid = is_valid and error_dict["category_ids_are_unique"]
+        if not error_dict["category_ids_are_unique"]:
             logging.error(f"{fail_message} There are duplicated category ids.")
-            return False
-        if not self._licenses_ids_are_unique(self.json_data):
+
+        # check if the licenses ids are unique
+        error_dict["licenses_ids_are_unique"] = self._licenses_ids_are_unique(self.json_data)
+        is_valid = is_valid and error_dict["licenses_ids_are_unique"]
+        if not error_dict["licenses_ids_are_unique"]:
             logging.error(f"{fail_message} There are duplicated licenses ids.")
-            return False
-        if not self._image_ids_are_unique(self.json_data):
+
+        # check if the image ids are unique
+        error_dict["image_ids_are_unique"] = self._image_ids_are_unique(self.json_data)
+        is_valid = is_valid and error_dict["image_ids_are_unique"]
+        if not error_dict["image_ids_are_unique"]:
             logging.error(f"{fail_message} There are duplicated image ids.")
-            return False
-        if not self._annotation_ids_are_unique(self.json_data):
+
+        # check if the annotation ids are unique
+        error_dict["annotation_ids_are_unique"] = self._annotation_ids_are_unique(self.json_data)
+        is_valid = is_valid and error_dict["annotation_ids_are_unique"]
+        if not error_dict["annotation_ids_are_unique"]:
             logging.error(f"{fail_message} There are duplicated annotation ids.")
-            return False
-        if not self._annotations_have_valid_image_id(self.json_data):
+
+        # check if the annotations have valid image id
+        error_dict["annotations_have_valid_image_id"] = self._annotations_have_valid_image_id(self.json_data)
+        is_valid = is_valid and error_dict["annotations_have_valid_image_id"]
+        if not error_dict["annotations_have_valid_image_id"]:
             logging.error(f"{fail_message} There are annotations with invalid image id.")
-            return False
-        if not self._annotations_have_valid_category_id(self.json_data):
+
+        # check if the annotations have valid category id
+        error_dict["annotations_have_valid_category_id"] = self._annotations_have_valid_category_id(self.json_data)
+        is_valid = is_valid and error_dict["annotations_have_valid_category_id"]
+        if not error_dict["annotations_have_valid_category_id"]:
             logging.error(f"{fail_message} There are annotations with invalid category id.")
-            return False
-        logging.info(" | Test passed.")
-        return True
+
+        if is_valid:
+            logging.info(" | Test passed.")
+
+        return is_valid, error_dict
 
     def _has_valid_dataset_tree(self, dataset_dir: Union[str, Path]) -> bool:
         """

--- a/src/cocohelper/validator.py
+++ b/src/cocohelper/validator.py
@@ -5,37 +5,47 @@ from typing import Dict, List, Optional, Type, Union, Sequence, Any, Tuple
 from functools import partial
 import logging
 import os
-from cocohelper import COCOHelper
+from pathlib import Path
+#from cocohelper import COCOHelper
 
 
 class COCOValidator:
 
     def __init__(
             self,
-            coco_helper: COCOHelper
+            json_data: Dict,
+            dataset_dir: Union[str, Path]
     ):
         """This class validates COCO datasets."""
-        self.helper = coco_helper
+        self.json_data = json_data
+        self.dataset_dir = dataset_dir
 
     def validate_dir(
             self,
-            dataset_dir: str,
             json_fname: str = 'coco.json'
     ) -> bool:
-        """Checks the COCO dataset validity based on the dir structure."""
+        """
+        Checks the COCO dataset validity based on the dir structure.
+
+        Args:
+            json_fname: the name of the json file containing the COCO dataset.
+
+        Returns:
+            True if this is a valid COCO dataset.
+        """
         # TODO: throw specific exception instead of returning or using asserts
         logging.info("\n")
         logging.info("Checking COCO dataset validity...")
         fail_message = " | Test failed: this is not a valid COCO dataset:"
 
         # check folder tree:
-        if not self._has_valid_dataset_tree():
+        if not self._has_valid_dataset_tree(self.dataset_dir):
             logging.error(f"{fail_message} Folders are not organised as expected by a COCO dataset.")
             return False
 
         # make sure json_fname is a valid name for the json file:
         suffix = json_fname.rsplit(os.sep)[-1]
-        fname = os.path.join(os.path.join(dataset_dir, "annotations"), suffix)
+        fname = os.path.join(os.path.join(self.dataset_dir, "annotations"), suffix)
         if not fname.endswith(".json"):
             raise ValueError("The annotation file name must end with the extension '.json'")
 
@@ -54,46 +64,45 @@ class COCOValidator:
         fail_message = " | Test failed: this is not a valid COCO dataset:"
 
         # check folder tree:
-        if not self._has_valid_dataset_tree():
+        if not self._has_valid_dataset_tree(self.dataset_dir):
             logging.error(f"{fail_message} Folders are not organised as expected by a COCO dataset.")
             return False
 
         # start verifying dataset validity
-        data = self.helper.to_json_dataset()
-        if not self._json_has_mandatory_keys(data):
+        if not self._json_has_mandatory_keys(self.json_data):
             logging.error(f"{fail_message} There are missing mandatory keys in the json file.")
             return False
-        if not self._categories_have_mandatory_keys(data):
+        if not self._categories_have_mandatory_keys(self.json_data):
             logging.error(f"{fail_message} There are missing mandatory keys in the COCO categories.")
             return False
-        if not self._images_have_mandatory_keys(data):
+        if not self._images_have_mandatory_keys(self.json_data):
             logging.error(f"{fail_message} There are missing mandatory keys in the COCO images.")
             return False
-        if not self._annotations_have_mandatory_keys(data):
+        if not self._annotations_have_mandatory_keys(self.json_data):
             logging.error(f"{fail_message} There are missing mandatory keys in the COCO annotations.")
             return False
-        if not self._category_ids_are_unique(data):
+        if not self._category_ids_are_unique(self.json_data):
             logging.error(f"{fail_message} There are duplicated category ids.")
             return False
-        if not self._licenses_ids_are_unique(data):
+        if not self._licenses_ids_are_unique(self.json_data):
             logging.error(f"{fail_message} There are duplicated licenses ids.")
             return False
-        if not self._image_ids_are_unique(data):
+        if not self._image_ids_are_unique(self.json_data):
             logging.error(f"{fail_message} There are duplicated image ids.")
             return False
-        if not self._annotation_ids_are_unique(data):
+        if not self._annotation_ids_are_unique(self.json_data):
             logging.error(f"{fail_message} There are duplicated annotation ids.")
             return False
-        if not self._annotations_have_valid_image_id(data):
+        if not self._annotations_have_valid_image_id(self.json_data):
             logging.error(f"{fail_message} There are annotations with invalid image id.")
             return False
-        if not self._annotations_have_valid_category_id(data):
+        if not self._annotations_have_valid_category_id(self.json_data):
             logging.error(f"{fail_message} There are annotations with invalid category id.")
             return False
         logging.info(" | Test passed.")
         return True
 
-    def _has_valid_dataset_tree(self) -> bool:
+    def _has_valid_dataset_tree(self, dataset_dir: Union[str, Path]) -> bool:
         """
         Check dataset directory tree validity
 
@@ -101,7 +110,7 @@ class COCOValidator:
             True if the dataset tree is valid, False otherwise
         """
         # 1) there exist a folder named annotations:
-        cond1 = os.path.exists(os.path.join(self.helper.root_path, "annotations"))
+        cond1 = os.path.exists(os.path.join(dataset_dir, "annotations"))
 
         # TODO: 2) all the data is under a separate sub-folder. Consider adding checks here
         # folder_content = glob(os.path.join(self.dataset_dir, "*.*"))

--- a/tests/unit/test_cocohelper/test_helper/test_validation.py
+++ b/tests/unit/test_cocohelper/test_helper/test_validation.py
@@ -1,19 +1,19 @@
 import pytest
-from shutil import rmtree
 from cocohelper import COCOHelper
-
-# TODO: Create new tests (not dependant from pycocotools' COCO class)
 from cocohelper.errors.validation_error import COCOValidationError
-from cocohelper.validator import COCOValidator
 
 
-# TODO: improve test suite, use AAA approach (Arrange, Act, Assert), use pytest test Classes and fixtures.
+@pytest.fixture
+def ch():
+    return COCOHelper.load_json('tests/data/coco_dataset/annotations/coco.json')
 
-ch = COCOHelper.load_json('tests/data/coco_dataset/annotations/coco.json')
-coco = ch.to_coco()
+
+@pytest.fixture
+def ch_invalid():
+    return COCOHelper.load_json('tests/data/coco_dataset/annotations/coco_invalid.json')
 
 
-def test_validation():
+def test_init_validation():
     has_error = False
     try:
         COCOHelper.load_json('tests/data/coco_dataset/annotations/coco_invalid.json',
@@ -22,3 +22,26 @@ def test_validation():
         has_error = True
 
     assert has_error
+
+
+def test_copy_validation(ch_invalid):
+    has_error = False
+    try:
+        ch_invalid.copy(validate=True)
+
+    except COCOValidationError:
+        has_error = True
+
+    assert has_error
+
+
+def test_validations(ch, ch_invalid):
+    # good dataset
+    is_dir_valid = ch.validator.validate_dir(json_fname='coco.json')
+    # invalid dataset
+    is_data_valid, error_dict = ch_invalid.validator.validate_dataset()
+
+    assert is_dir_valid
+    assert not is_data_valid
+    assert len(error_dict) == 11
+    assert sum(error_dict.values()) == 10


### PR DESCRIPTION
With this merge it'll be implemented the following changes:

1. dataframe.to_dict: solved pandas warning for future implementation of "to_dict"
2. Solved circular dependencies between COCOHelper and COCOValidator: added property (validator) to COCOHelper for creating on the fly a validator to validate the dataset, it's been implemented into a function called both in __init__ and copy.
3. helper.__init__: improved validation with a function that runs the checks and raises an exception in case 1 or more checks are failed, moreover, it returns a log with all the data; 
4. helper.copy: added validation as well, previously not implemented
